### PR TITLE
🐛 FIX: Boostrap -> Bootstrap in code/docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,10 +79,10 @@ elif theme_name == "alabaster":
     ]
 elif theme_name == "pydata_sphinx_theme":
     html_theme = "pydata_sphinx_theme"
-    panels_add_boostrap_css = False
+    panels_add_bootstrap_css = False
 elif theme_name == "sphinx_book_theme":
     html_theme = "sphinx_book_theme"
-    panels_add_boostrap_css = False
+    panels_add_bootstrap_css = False
     html_theme_options = {
         "single_page": True,
     }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -142,7 +142,7 @@ to your extensions list, e.g.:
 
 This extension includes the bootstrap 4 CSS classes relevant to panels.
 They will be loaded by default but, if you are already using a bootstrap theme,
-you can disable this by adding ``panels_add_boostrap_css = False`` to your ``conf.py``.
+you can disable this by adding ``panels_add_bootstrap_css = False`` to your ``conf.py``.
 
 You can also change the delimiter regexes used by adding ``panel_delimiters`` to your ``conf.py``,
 e.g. the default value (panels, header, footer) is:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,9 +140,13 @@ to your extensions list, e.g.:
         ...
     ]
 
-This extension includes the bootstrap 4 CSS classes relevant to panels.
-They will be loaded by default but, if you are already using a bootstrap theme,
-you can disable this by adding ``panels_add_bootstrap_css = False`` to your ``conf.py``.
+This extension includes the bootstrap 4 CSS classes relevant to panels and loads it by default.
+However if you already load your own Bootstrap CSS (e.g., if your theme loads it already), you may choose *not* to add it with ``sphinx-panels``.
+To do so, use the following configuration in ``conf.py``:
+
+.. code-block:: python
+
+   panels_add_bootstrap_css = False
 
 You can also change the delimiter regexes used by adding ``panel_delimiters`` to your ``conf.py``,
 e.g. the default value (panels, header, footer) is:

--- a/sphinx_panels/__init__.py
+++ b/sphinx_panels/__init__.py
@@ -60,7 +60,14 @@ def update_css(app: Sphinx):
 
     # Add core CSS
     css_files = [r for r in resources.contents(css_module) if r.endswith(".css")]
-    if not app.config.panels_add_bootstrap_css:
+    if app.config.panels_add_boostrap_css is not None:
+        LOGGER.warning(
+            "`panels_add_boostrap_css` will be deprecated. Please use"
+            "`panels_add_bootstrap_css`."
+        )
+        app.config.panels_add_bootstrap_css = app.config.panels_add_boostrap_css
+
+    if app.config.panels_add_bootstrap_css is False:
         css_files = [name for name in css_files if "bootstrap" not in name]
     for filename in css_files:
         app.add_css_file(filename)
@@ -147,7 +154,8 @@ def depart_container(self, node: nodes.Node):
 
 def setup(app: Sphinx):
     app.add_directive("div", Div)
-    app.add_config_value("panels_add_bootstrap_css", True, "env")
+    app.add_config_value("panels_add_bootstrap_css", None, "env")
+    app.add_config_value("panels_add_boostrap_css", None, "env")
     app.add_config_value("panels_css_variables", {}, "env")
     app.add_config_value("panels_dev_mode", False, "env")
     app.connect("builder-inited", update_css)

--- a/sphinx_panels/__init__.py
+++ b/sphinx_panels/__init__.py
@@ -60,7 +60,7 @@ def update_css(app: Sphinx):
 
     # Add core CSS
     css_files = [r for r in resources.contents(css_module) if r.endswith(".css")]
-    if not app.config.panels_add_boostrap_css:
+    if not app.config.panels_add_bootstrap_css:
         css_files = [name for name in css_files if "bootstrap" not in name]
     for filename in css_files:
         app.add_css_file(filename)
@@ -147,7 +147,7 @@ def depart_container(self, node: nodes.Node):
 
 def setup(app: Sphinx):
     app.add_directive("div", Div)
-    app.add_config_value("panels_add_boostrap_css", True, "env")
+    app.add_config_value("panels_add_bootstrap_css", True, "env")
     app.add_config_value("panels_css_variables", {}, "env")
     app.add_config_value("panels_dev_mode", False, "env")
     app.connect("builder-inited", update_css)


### PR DESCRIPTION
I noticed in the docs that there seemed to be a typo for the bootstrap config, it was called `boostrap` instead of `bootstrap`.

But then when I looked at the code, I saw that the config was also `boostrap` and the docs were technically correct.

So this PR changes `boostrap` to `bootstrap` in the config and docs, assuming that this was a typo. Is that right @chrisjsewell ?

NOTE: when this changes we'll also need to do the same thing in Jupyter Book...I dunno how we missed this one.

This makes me think we may actually need to run a deprecation cycle so that users aren't jarred by the change. @chrisjsewell what do you think?