### PR TITLE
🔧 MAINT: adding check for bootstrap themes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,10 +79,8 @@ elif theme_name == "alabaster":
     ]
 elif theme_name == "pydata_sphinx_theme":
     html_theme = "pydata_sphinx_theme"
-    panels_add_bootstrap_css = False
 elif theme_name == "sphinx_book_theme":
     html_theme = "sphinx_book_theme"
-    panels_add_bootstrap_css = False
     html_theme_options = {
         "single_page": True,
     }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,7 +148,7 @@ This extension includes the bootstrap 4 CSS classes relevant to panels and loads
 However, ``sphinx-panels`` bootstrap CSS will **not** be used if one of the following is true:
 
 - **You're using one of these bootstrap-based Sphinx themes**: ``sphinx_book_theme``, ``pydata_sphinx_theme``, ``bootstrap``.
-- **You manually specify that bootstrap CSS should not be loaded**. 
+- **You manually specify that bootstrap CSS should not be loaded**.
   To do so, use the following configuration in ``conf.py``:
 
   .. code-block:: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,13 +140,23 @@ to your extensions list, e.g.:
         ...
     ]
 
+Control whether bootstrap CSS is loaded
+---------------------------------------
+
 This extension includes the bootstrap 4 CSS classes relevant to panels and loads it by default.
-However if you already load your own Bootstrap CSS (e.g., if your theme loads it already), you may choose *not* to add it with ``sphinx-panels``.
-To do so, use the following configuration in ``conf.py``:
 
-.. code-block:: python
+However, ``sphinx-panels`` bootstrap CSS will **not** be used if one of the following is true:
 
-   panels_add_bootstrap_css = False
+- **You're using one of these bootstrap-based Sphinx themes**: ``sphinx_book_theme``, ``pydata_sphinx_theme``, ``bootstrap``.
+- **You manually specify that bootstrap CSS should not be loaded**. 
+  To do so, use the following configuration in ``conf.py``:
+
+  .. code-block:: python
+
+      panels_add_bootstrap_css = False
+
+Edit the regexes that separate panel sections
+---------------------------------------------
 
 You can also change the delimiter regexes used by adding ``panel_delimiters`` to your ``conf.py``,
 e.g. the default value (panels, header, footer) is:

--- a/sphinx_panels/__init__.py
+++ b/sphinx_panels/__init__.py
@@ -67,7 +67,14 @@ def update_css(app: Sphinx):
         )
         app.config.panels_add_bootstrap_css = app.config.panels_add_boostrap_css
 
-    if app.config.panels_add_bootstrap_css is False:
+    bootstrap_themes = ["sphinx_book_theme", "pydata_sphinx_theme", "bootstrap"]
+    if app.config.html_theme in bootstrap_themes:
+        LOGGER.info(f"Using Sphinx theme for Bootstrap CSS: {app.config.html_theme}")
+        bootstrap_loaded = True
+    else:
+        bootstrap_loaded = False
+
+    if app.config.panels_add_bootstrap_css is False or bootstrap_loaded:
         css_files = [name for name in css_files if "bootstrap" not in name]
     for filename in css_files:
         app.add_css_file(filename)


### PR DESCRIPTION
This adds a check for the theme name, and if it is one of the "bootstrap" themes that we know of, it automatically does *not* add bootstrap CSS through `sphinx-panels`.

I wasn't sure how to test this, so for the time being I've disabled `panels_add_bootstrap_css` for the two bootstrap themes that we demo, and I figure at least we can confirm that bootstrap is behaving as-expected on those two demos to make sure this is working. WDYT?