### PR TITLE
👌 IMPROVE: allow to specify a custom reference role for link-button

### DIFF
--- a/sphinx_panels/button.py
+++ b/sphinx_panels/button.py
@@ -18,25 +18,34 @@ def setup_link_button(app):
 
 def create_ref_node(link_type, uri, text, tooltip):
     innernode = nodes.inline(text, text)
-    if link_type == "ref":
-        ref_node = addnodes.pending_xref(
-            reftarget=unquote(uri),
-            reftype="any",
-            # refdoc=self.env.docname,
-            refdomain="",
-            refexplicit=True,
-            refwarn=True,
-        )
-        innernode["classes"] = ["xref", "any"]
-        # if tooltip:
-        #     ref_node["reftitle"] = tooltip
-        #     ref_node["title"] = tooltip
-        # TODO this doesn't work
-    else:
+    if link_type == "url":
         ref_node = nodes.reference()
         ref_node["refuri"] = uri
         if tooltip:
             ref_node["reftitle"] = tooltip
+    else:
+        if link_type == "ref":
+            link_type = "any"
+        if ":" in link_type:
+            refdomain, reftype = link_type.split(":", 1)
+            classes = ['xref', refdomain, "{0}-{1}".format(refdomain, reftype)]
+        else:
+            refdomain, reftype = "", link_type
+            classes = ['xref', reftype]
+        # breakpoint()
+        ref_node = addnodes.pending_xref(
+            reftarget=unquote(uri),
+            reftype=reftype,
+            # refdoc=self.env.docname,
+            refdomain=refdomain,
+            refexplicit=True,
+            refwarn=True,
+        )
+        innernode["classes"] = classes
+        # if tooltip:
+        #     ref_node["reftitle"] = tooltip
+        #     ref_node["title"] = tooltip
+        # TODO this doesn't work
     ref_node += innernode
     return ref_node
 
@@ -48,7 +57,7 @@ class LinkButton(SphinxDirective):
     required_arguments = 1
     final_argument_whitespace = True
     option_spec = {
-        "type": lambda arg: directives.choice(arg, ("url", "ref")),
+        "type": lambda arg: directives.choice(arg, ("url", "ref", "any", "doc", "std:ref")),
         "text": directives.unchanged,
         "tooltip": directives.unchanged,
         "classes": directives.unchanged,


### PR DESCRIPTION
While trying to use sphinx-panels for the pandas docs (finally .. ;)), I ran into an issue with the link-button: because it's hardcoded to use an "any" role, this can give ambiguous targets ("WARNING: more than one target found for 'any' cross-reference ..."). 
While in actual rst, you could use ``` :ref:`target` ``` or ``` :doc:`target` ``` or ``` :func:`target` ```, .. to be more specific.

So I think it would be nice if it would be possible for `link-button` directive to support this as well. There is already a `:type:` keyword (which now takes "url" or "ref"), which could be used for this. The only problem is that for backwards compatibility, "ref" should keep meaning "any", and not actually "ref". It also seems that sphinx automatically changes "ref" into "std:ref" (or this might depend on your settings), and specifying "ref" as the `reftype` without a domain gives errors in sphinx. So you have to use "std:ref" as a user. 

I directly made a PR instead of an issue because I was trying it out anyway if it could work, and the diff might make my question/suggestion more concrete. 
If there is interest in this, I can further clean-up the PR. 