### PR TITLE
DOCS: Add recommendation for sphinx-design

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     - id: check-manifest
 
   - repo: https://github.com/psf/black
-    rev: "22.3"
+    rev: "22.3.0"
     hooks:
     - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,12 +28,12 @@ repos:
     - id: check-manifest
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: "22.3"
     hooks:
     - id: black
 
   - repo: https://github.com/executablebooks/web-compile
-    rev: v0.2.0
+    rev: v0.2.2
     hooks:
       - id: web-compile
         files: >-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code style: black][black-badge]][black-link]
 [![PyPI][pypi-badge]][pypi-link]
 
-🚨This repository is not actively maintained. Use [`sphinx-design`](https://github.com/executablebooks/sphinx-design) instead!🚨
+🚨This repository is not actively maintained. Use [`sphinx-design`](https://github.com/executablebooks/sphinx-design) instead! See [the migration guide](https://sphinx-design.readthedocs.io/en/latest/get_started.html#migrating-from-sphinx-panels) for more information.🚨
 
 A sphinx extension for creating document components optimised for HTML+CSS.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code style: black][black-badge]][black-link]
 [![PyPI][pypi-badge]][pypi-link]
 
-🚨This repository is not actively maintained. Use [`sphinx-design`](https://github.com/executablebooks/sphinx-design) instead! See [the migration guide](https://sphinx-design.readthedocs.io/en/latest/get_started.html#migrating-from-sphinx-panels) for more information.🚨
+🚨This repository is not actively maintained. Use [`sphinx-design`](https://github.com/executablebooks/sphinx-design) instead! See [the migration guide](https://sphinx-design.readthedocs.io/en/latest/get_started.html#migrating-from-sphinx-panels) and [this github issue](https://github.com/executablebooks/sphinx-design/issues/51) for more information.🚨
 
 A sphinx extension for creating document components optimised for HTML+CSS.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Code style: black][black-badge]][black-link]
 [![PyPI][pypi-badge]][pypi-link]
 
+🚨This repository is not actively maintained. Use [`sphinx-design`](https://github.com/executablebooks/sphinx-design) instead!🚨
+
 A sphinx extension for creating document components optimised for HTML+CSS.
 
 - The `panels` directive creates panels of content in a grid layout, utilising both the Bootstrap 4 [grid system](https://getbootstrap.com/docs/4.0/layout/grid/), and [cards layout](https://getbootstrap.com/docs/4.0/components/card/).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ sphinx-panels
 
    This repository is not actively maintained.
    Use `sphinx-design <https://github.com/executablebooks/sphinx-design>`_ instead!
-   See `the migration guide <https://sphinx-design.readthedocs.io/en/latest/get_started.html#migrating-from-sphinx-panels>`_ for more information.
+   See `the migration guide <https://sphinx-design.readthedocs.io/en/latest/get_started.html#migrating-from-sphinx-panels>`_ and `this github issue <https://github.com/executablebooks/sphinx-design/issues/51>`_ for more information.
 
 A sphinx extension for creating panels in a grid layout or as drop-downs.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,10 @@
 sphinx-panels
 =============
 
+.. warning::
+
+   This repository is not actively maintained. Use `sphinx-design <https://github.com/executablebooks/sphinx-design>`_ instead!
+
 A sphinx extension for creating panels in a grid layout or as drop-downs.
 
 - The ``panels`` directive creates panels of content in a grid layout, utilising both the bootstrap 4

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,9 @@ sphinx-panels
 
 .. warning::
 
-   This repository is not actively maintained. Use `sphinx-design <https://github.com/executablebooks/sphinx-design>`_ instead!
+   This repository is not actively maintained.
+   Use `sphinx-design <https://github.com/executablebooks/sphinx-design>`_ instead!
+   See `the migration guide <https://sphinx-design.readthedocs.io/en/latest/get_started.html#migrating-from-sphinx-panels>`_ for more information.
 
 A sphinx extension for creating panels in a grid layout or as drop-downs.
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
     ],
     extras_require={
         "themes": [
-            "sphinx>=4",
+            # ref: https://github.com/sphinx-doc/sphinx/issues/10291
+            "jinja<3.1",
             "sphinx-rtd-theme",
             "pydata-sphinx-theme~=0.4.0",
             "sphinx-book-theme~=0.0.36",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     extras_require={
         "themes": [
             # ref: https://github.com/sphinx-doc/sphinx/issues/10291
-            "jinja<3.1",
+            "Jinja2<3.1",
             "sphinx-rtd-theme",
             "pydata-sphinx-theme~=0.4.0",
             "sphinx-book-theme~=0.0.36",

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     ],
     extras_require={
         "themes": [
+            "sphinx>=4",
             "sphinx-rtd-theme",
             "pydata-sphinx-theme~=0.4.0",
             "sphinx-book-theme~=0.0.36",


### PR DESCRIPTION
This clarifies that this repository is no longer actively maintained, and suggests that people use `sphinx-design` instead. This should help steer newcomers to this package to `sphinx-design` so that they use a more up-to-date tool.