### PR TITLE
Require Sphinx 2.1.0 and above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "docutils",
-        "sphinx>=2,<5",
+        "sphinx>=2.1,<5",
         'importlib-resources~=3.0.0; python_version < "3.7"',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ usedevelop = true
 [testenv:py{36,37,38,39}-sphinx{2,3,4}]
 extras = testing
 deps =
-    sphinx2: sphinx>=2,<3
+    sphinx2: sphinx>=2.1,<3
     sphinx3: sphinx>=3,<4
     sphinx4: sphinx>=4,<5
 commands = pytest {posargs}


### PR DESCRIPTION
This extension use `sphinx.transforms.post_transforms.SphinxPostTransform` helper class, and it is introduced in Sphinx 2.1.0

ref: https://www.sphinx-doc.org/en/master/changes.html#release-2-1-0-released-jun-02-2019