### PR TITLE
Make the tests pass with Sphinx 7.x

### DIFF
--- a/tests/test_sphinx/test_sources_dropdown_basic_.xml
+++ b/tests/test_sphinx/test_sources_dropdown_basic_.xml
@@ -1,4 +1,4 @@
-<document source="source">
+<document source="source" translation_progress="{'total': 0, 'translated': 0}">
     <section ids="title" names="title">
         <title>
             Title

--- a/tests/test_sphinx/test_sources_tabbed_basic_.xml
+++ b/tests/test_sphinx/test_sources_tabbed_basic_.xml
@@ -1,4 +1,4 @@
-<document source="source">
+<document source="source" translation_progress="{'total': 0, 'translated': 0}">
     <section ids="title" names="title">
         <title>
             Title


### PR DESCRIPTION
This adds compat with Sphinx 7.x.  Applied straight from the Debian patch:  https://salsa.debian.org/python-team/packages/sphinx-panels/-/blob/debian/master/debian/patches/Make-the-tests-pass-with-Sphinx-7.x.patch

CC @mitya57 @mgorny